### PR TITLE
Handle escape backslashes in object data

### DIFF
--- a/tests/test_unescape_strings.py
+++ b/tests/test_unescape_strings.py
@@ -1,0 +1,13 @@
+from mcp_server import _unescape_strings
+
+
+def test_unescape_strings_removes_backslashes():
+    data = {"Description": "ООО \\'БАУМ ASTRA\\'"}
+    cleaned = _unescape_strings(data)
+    assert cleaned["Description"] == "ООО 'БАУМ ASTRA'"
+
+
+def test_unescape_strings_keeps_other_backslashes():
+    data = {"path": "C:\\Temp\\file"}
+    cleaned = _unescape_strings(data)
+    assert cleaned["path"] == "C:\\Temp\\file"


### PR DESCRIPTION
## Summary
- sanitize string values by stripping escape backslashes before sending data to OData
- apply sanitization for create_object and update_object tool calls
- add tests for backslash removal helper

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6cef251ec83288fd7aa9923a8f059