### PR TITLE
Validate OData expand segments against navigation properties

### DIFF
--- a/odata_client.py
+++ b/odata_client.py
@@ -628,7 +628,7 @@ class ODataClient:
 
             root = ET.fromstring(metadata["raw"])
 
-            # Map EntityType -> properties
+            # Map EntityType -> properties and navigation properties
             etype_props: Dict[str, Dict[str, Any]] = {}
             for node in root.iter():
                 if node.tag.endswith("EntityType"):
@@ -636,6 +636,7 @@ class ODataClient:
                     if not et_name:
                         continue
                     props: Dict[str, Dict[str, Any]] = {}
+                    nav_props: Dict[str, Dict[str, Any]] = {}
                     for child in list(node):
                         if child.tag.endswith("Property"):
                             pname = child.get("Name")
@@ -643,7 +644,15 @@ class ODataClient:
                             nullable = (child.get("Nullable", "true").lower() == "true")
                             if pname:
                                 props[pname] = {"type": ptype, "nullable": nullable}
-                    etype_props[et_name] = props
+                        elif child.tag.endswith("NavigationProperty"):
+                            pname = child.get("Name")
+                            ptype = child.get("Type")
+                            if pname:
+                                nav_props[pname] = {"type": ptype}
+                    etype_props[et_name] = {
+                        "properties": props,
+                        "navigation_properties": nav_props,
+                    }
 
             # Read EntitySet(s) from any EntityContainer
             entity_sets: Dict[str, Dict[str, Any]] = {}
@@ -656,9 +665,11 @@ class ODataClient:
                             if not name:
                                 continue
                             et_short = (etype or "").split(".")[-1]
+                            et_info = etype_props.get(et_short, {})
                             entity_sets[name] = {
                                 "entity_type": etype,
-                                "properties": etype_props.get(et_short, {}),
+                                "properties": et_info.get("properties", {}),
+                                "navigation_properties": et_info.get("navigation_properties", {}),
                             }
 
             if entity_sets:

--- a/tests/test_expand_validation.py
+++ b/tests/test_expand_validation.py
@@ -1,0 +1,93 @@
+import logging
+
+import mcp_server
+from mcp_server import MCPServer
+
+
+class DummyResponse:
+    def values(self):
+        return [{"Ref_Key": "1"}]
+
+
+class DummyBuilder:
+    def __init__(self, client):
+        self.client = client
+        self.expanded = None
+
+    def expand(self, fields):
+        self.expanded = fields
+        return self
+
+    def top(self, count):
+        return self
+
+    def filter(self, flt):
+        return self
+
+    def get(self):
+        return DummyResponse()
+
+    def create(self, data):
+        return DummyResponse()
+
+    def update(self, data=None):
+        return DummyResponse()
+
+
+class DummyClient:
+    def __init__(self, *args, **kwargs):
+        self.http_code = 200
+        self.http_message = "OK"
+        self.odata_code = None
+        self.odata_message = None
+        self.last_id = None
+        self.last_builder = None
+
+    def get_metadata(self):
+        return {
+            "Catalog_Номенклатура": {
+                "entity_type": "t",
+                "properties": {},
+                "navigation_properties": {"Parent": {}, "ЕдиницаИзмерения": {}}
+            }
+        }
+
+    def __getattr__(self, item):
+        self.last_builder = DummyBuilder(self)
+        return self.last_builder
+
+    def get_http_code(self):
+        return self.http_code
+
+    def get_http_message(self):
+        return self.http_message
+
+    def get_error_code(self):
+        return self.odata_code
+
+    def get_error_message(self):
+        return self.odata_message
+
+    def get_last_id(self):
+        return self.last_id
+
+
+def create_server(monkeypatch):
+    monkeypatch.setattr(mcp_server, "ODataClient", DummyClient)
+    return MCPServer("http://example.com")
+
+
+def test_invalid_expand_segment_skipped(monkeypatch, caplog):
+    server = create_server(monkeypatch)
+    with caplog.at_level(logging.WARNING):
+        server.list_objects("Catalog_Номенклатура", expand="Unknown")
+    assert server.client.last_builder.expanded is None
+    assert "Navigation property" in caplog.text
+
+
+def test_mix_expand_segments(monkeypatch, caplog):
+    server = create_server(monkeypatch)
+    with caplog.at_level(logging.WARNING):
+        server.list_objects("Catalog_Номенклатура", expand="Parent,Unknown")
+    assert server.client.last_builder.expanded == "Parent"
+    assert "Unknown" in caplog.text


### PR DESCRIPTION
## Summary
- parse navigation properties in metadata to expose them through `get_entity_schema`
- validate `$expand` fields against navigation properties and skip invalid segments
- add tests ensuring unknown expand segments are logged and ignored

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6e38c79b08328994615816e548eaa