### PR TITLE
Handle numeric search fields without substring filters

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -445,16 +445,12 @@ class MCPServer:
             resp = builder.get()
         except Exception as e:
             logger.warning("GET failed for %s with %s", object_name, e)
-            self.client.http_code = None
-            self.client.http_message = str(e)
-            self.client.odata_code = None
-            self.client.odata_message = None
             return [], {
-                "http_code": None,
-                "http_message": str(e),
-                "odata_error_code": None,
-                "odata_error_message": None,
-                "last_id": None,
+                "http_code": self.client.get_http_code(),
+                "http_message": self.client.get_http_message() or str(e),
+                "odata_error_code": self.client.get_error_code(),
+                "odata_error_message": self.client.get_error_message(),
+                "last_id": self.client.get_last_id(),
                 "data": None,
             }
         vals = resp.values() or []
@@ -489,22 +485,27 @@ class MCPServer:
         safe = (value or "").replace("'", "''")
         return f"{field} eq '{safe}'"
 
-    def _compose_expr_substr(self, field: str, value: str) -> str:
-        safe = (value or "").replace("'", "''")
+    def _compose_expr_substr(self, field: str, value: Any) -> str:
+        safe = str(value or "").replace("'", "''")
         return f"substringof('{safe}', {field})"
 
-    def _compose_expr_substr_ci(self, field: str, value: str) -> str:
-        safe = (value or "").lower().replace("'", "''")
+    def _compose_expr_substr_ci(self, field: str, value: Any) -> str:
+        safe = str(value or "").lower().replace("'", "''")
         return f"substringof('{safe}', tolower({field}))"
 
     def _progressive_attempts_for_string(
         self, object_name: str, field: str, value: str, include_only_elements: bool
     ) -> List[str]:
-        attempts = [
-            self._compose_expr_eq(field, value),
-            self._compose_expr_substr(field, value),
-            self._compose_expr_substr_ci(field, value),
-        ]
+        attempts = [self._compose_expr_eq(field, value)]
+        schema = self.get_entity_schema(object_name) or {}
+        props: Dict[str, Dict[str, Any]] = schema.get("properties", {}) or {}
+        if props.get(field, {}).get("type") == "Edm.String":
+            attempts.extend(
+                [
+                    self._compose_expr_substr(field, value),
+                    self._compose_expr_substr_ci(field, value),
+                ]
+            )
         if include_only_elements and self._has_isfolder(object_name):
             attempts = [f"{a} and IsFolder eq false" for a in attempts]
         return attempts
@@ -524,9 +525,9 @@ class MCPServer:
         # Определим строковые поля по типу из схемы
         schema = self.get_entity_schema(object_name) or {}
         props: Dict[str, Dict[str, Any]] = schema.get("properties", {}) or {}
-        string_fields: List[Tuple[str, str]] = []
+        string_fields: List[Tuple[str, Any]] = []
         for k, v in filters.items():
-            if isinstance(v, str) and (props.get(k, {}).get("type", "").endswith("String")):
+            if props.get(k, {}).get("type") == "Edm.String":
                 string_fields.append((k, v))
 
         # 1) substringof для каждого строкового поля поверх eq остальных
@@ -826,6 +827,7 @@ class MCPServer:
 
         def exec_attempts(attempt_list: List[str]) -> Dict[str, Any]:
             nonlocal top, expand, object_name
+            res: Dict[str, Any] = {}
             for flt in attempt_list:
                 vals, res = self._exec_get(object_name, flt, top, expand)
                 if vals:
@@ -835,6 +837,8 @@ class MCPServer:
                     else:
                         res["data"] = vals
                     return res
+                if res.get("http_code") == 400 and res.get("odata_error_code") == 21:
+                    continue
             # если все пусто — вернём последний res (или “пусто”)
             if attempt_list:
                 return res

--- a/tests/test_number_search.py
+++ b/tests/test_number_search.py
@@ -1,0 +1,33 @@
+from mcp_server import MCPServer
+
+
+class DummyClient:
+    def __init__(self, metadata):
+        self._metadata = metadata
+
+    def get_metadata(self):
+        return self._metadata
+
+
+def make_server(metadata):
+    srv = MCPServer.__new__(MCPServer)
+    srv.client = DummyClient(metadata)
+    return srv
+
+
+def test_progressive_dict_numeric_field():
+    metadata = {
+        "Entity": {"properties": {"Number": {"type": "Edm.Int32"}}}
+    }
+    srv = make_server(metadata)
+    attempts = srv._progressive_attempts_for_dict("Entity", {"Number": 123}, False)
+    assert attempts == ["Number eq 123"]
+
+
+def test_progressive_string_numeric_field():
+    metadata = {
+        "Entity": {"properties": {"Number": {"type": "Edm.Int32"}}}
+    }
+    srv = make_server(metadata)
+    attempts = srv._progressive_attempts_for_string("Entity", "Number", "123", False)
+    assert attempts == ["Number eq '123'"]


### PR DESCRIPTION
## Summary
- Generate `substringof` filters only for fields typed as `Edm.String`
- Skip 400/21 errors in search strategies to try the next filter
- Add tests verifying numeric fields use only exact comparisons

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6e39fd1448328b804b589b8efecb7